### PR TITLE
update cmake package

### DIFF
--- a/pkgs/cmake/build.textproto
+++ b/pkgs/cmake/build.textproto
@@ -13,8 +13,7 @@ build_step: <
   argv: "--parallel=8"
   argv: "--"
   argv: "-DBUILD_CursesDialog=ON"
-# argv: "-DCURSES_LIBRARY=/usr/lib/libncurses.so"
-  argv: "-DCURSES_LIBRARY=/ro/ncurses-amd64-6.1-5/lib/libncurses.so.6"
+  argv: "-DCURSES_LIBRARY=/ro/lib/libncurses.so"
   argv: "-DCMAKE_VERBOSE_MAKEFILE=ON"
 >
 

--- a/pkgs/cmake/build.textproto
+++ b/pkgs/cmake/build.textproto
@@ -5,10 +5,17 @@ version: "3.12.2-3"
 cbuilder: <>
 
 # build dependencies:
+dep: "ncurses"
 
 build_step: <
   argv: "${DISTRI_SOURCEDIR}/configure"
   argv: "--prefix=${DISTRI_PREFIX}"
+  argv: "--parallel=8"
+  argv: "--"
+  argv: "-DBUILD_CursesDialog=ON"
+# argv: "-DCURSES_LIBRARY=/usr/lib/libncurses.so"
+  argv: "-DCURSES_LIBRARY=/ro/ncurses-amd64-6.1-5/lib/libncurses.so.6"
+  argv: "-DCMAKE_VERBOSE_MAKEFILE=ON"
 >
 
 build_step: <


### PR DESCRIPTION
 - run concurrent build (cf https://github.com/distr1/distri/issues/38 discussion of the default value)
 - switch to verbose build print (afaiu the desired configuration for distri)
 - enable the ncurses tui

The last item is the most WIP of these as I don't fully understand what's
happening there. As you see in the change, I didn't manage by setting the
`CURSES_LIBRARY` to the location in `/usr/lib` but used the `/ro` location
instead. Strangely, the `/usr/lib` version makes it fine through most of the
build (detection by the configuration steps) but very late `make` fails
claiming it didn't have a rule to build `/usr/lib/libncurses.so`. Running
`distri build -debug` and inspecting the `distri-buildchroot` directory tree, I
noticed that `/usr/lib` doesn't exist in the chroot. Indicating the `/ro`
location for `libncurses.so` fixes that, though I dislike that I hardcode
the architecture and version in that way.
