### PR TITLE
Speed up package scanning (from 3.6s to <1s)

### DIFF
--- a/cmd/distri/internal/fuse/fuse.go
+++ b/cmd/distri/internal/fuse/fuse.go
@@ -345,6 +345,9 @@ func (fs *fuseFS) allocateInodeLocked() fuseops.InodeID {
 func (fs *fuseFS) mkExchangeDirAll(mu sync.Locker, path string) {
 	mu.Lock()
 	defer mu.Unlock()
+	if _, exists := fs.dirs[path]; exists {
+		return // fast path
+	}
 	components := strings.Split(path, "/")
 	for idx, component := range components[1:] {
 		path := strings.Join(components[:idx+2], "/")

--- a/cmd/distri/internal/fuse/fuse.go
+++ b/cmd/distri/internal/fuse/fuse.go
@@ -448,7 +448,7 @@ func (fs *fuseFS) scanPackagesSymlink(mu sync.Locker, rd *squashfs.Reader, pkg s
 		if !ok {
 			panic(fmt.Sprintf("BUG: fs.dirs[%q] not found", exchangePath))
 		}
-		sfis, err := rd.Readdir(inode)
+		sfis, err := rd.ReaddirNoStat(inode)
 		if err != nil {
 			return xerrors.Errorf("Readdir(%s, %v): %v", pkg, dir, err)
 		}

--- a/cmd/distri/internal/fuse/fuse.go
+++ b/cmd/distri/internal/fuse/fuse.go
@@ -380,10 +380,12 @@ func (fs *fuseFS) symlink(dir *dir, target string) {
 		if current.linkTarget == "" {
 			return // do not shadow exchange directories
 		}
-		if distri.ParseVersion(target).Pkg != distri.ParseVersion(current.linkTarget).Pkg {
+		versionTarget := distri.ParseVersion(target)
+		versionCurrent := distri.ParseVersion(current.linkTarget)
+		if versionTarget.Pkg != versionCurrent.Pkg {
 			return // different package already owns this link
 		}
-		if distri.PackageRevisionLess(target, current.linkTarget) {
+		if versionTarget.DistriRevision < versionCurrent.DistriRevision {
 			return // more recent link target already in place
 		}
 		for idx, entry := range dir.entries {

--- a/cmd/distri/mirror.go
+++ b/cmd/distri/mirror.go
@@ -80,9 +80,9 @@ func mirror(args []string) error {
 		}
 		for _, wk := range fuse.ExchangeDirs {
 			wk = strings.TrimPrefix(wk, "/")
-			inode, err := fuse.LookupPath(rd, wk)
+			inode, err := rd.LookupPath(wk)
 			if err != nil {
-				if _, ok := err.(*fuse.FileNotFoundError); ok {
+				if _, ok := err.(*squashfs.FileNotFoundError); ok {
 					continue
 				}
 				return err

--- a/internal/squashfs/reader.go
+++ b/internal/squashfs/reader.go
@@ -321,11 +321,11 @@ func (r *Reader) lookupPath(path string, followSymlink bool) (Inode, error) {
 		if !followSymlink {
 			continue
 		}
-		fi, err := r.Stat("", inode)
+		i, err := r.readInode(inode)
 		if err != nil {
 			return 0, xerrors.Errorf("Stat(%d): %v", inode, err)
 		}
-		if fi.Mode()&os.ModeSymlink > 0 {
+		if _, ok := i.(symlinkInodeHeader); ok {
 			target, err := r.ReadLink(inode)
 			if err != nil {
 				return 0, err

--- a/internal/squashfs/reader.go
+++ b/internal/squashfs/reader.go
@@ -450,10 +450,11 @@ func (r *Reader) readdir(dirInode Inode, stat bool) ([]os.FileInfo, error) {
 			//log.Printf("de: %+v", de)
 			nameBuf.Reset()
 			nameBuf.Grow(int(de.Size))
-			if _, err := io.CopyN(nameBuf, br, int64(de.Size)); err != nil {
+			nb := nameBuf.Bytes()[:de.Size]
+			if _, err := io.ReadFull(br, nb); err != nil {
 				return nil, err
 			}
-			name := nameBuf.String()
+			name := string(nb)
 			//log.Printf("name: %q", string(name))
 
 			var fi os.FileInfo

--- a/internal/squashfs/writer.go
+++ b/internal/squashfs/writer.go
@@ -176,6 +176,14 @@ type dirHeader struct {
 	InodeOffset uint32
 }
 
+func (d *dirHeader) Unmarshal(b []byte) {
+	_ = b[11]
+	e := binary.LittleEndian
+	d.Count = e.Uint32(b)
+	d.StartBlock = e.Uint32(b[4:])
+	d.InodeOffset = e.Uint32(b[8:])
+}
+
 type dirEntry struct {
 	Offset      uint16
 	InodeNumber int16
@@ -183,6 +191,15 @@ type dirEntry struct {
 	Size        uint16
 
 	// Followed by a byte array of Size bytes.
+}
+
+func (d *dirEntry) Unmarshal(b []byte) {
+	_ = b[7]
+	e := binary.LittleEndian
+	d.Offset = e.Uint16(b)
+	d.InodeNumber = int16(e.Uint16(b[2:]))
+	d.EntryType = e.Uint16(b[4:])
+	d.Size = e.Uint16(b[6:])
 }
 
 // xattr types

--- a/internal/squashfs/writer.go
+++ b/internal/squashfs/writer.go
@@ -157,6 +157,22 @@ type dirInodeHeader struct {
 	ParentInode uint32
 }
 
+func (d *dirInodeHeader) Unmarshal(b []byte) {
+	_ = b[31]
+	e := binary.LittleEndian
+	d.InodeType = e.Uint16(b)
+	d.Mode = e.Uint16(b[2:])
+	d.Uid = e.Uint16(b[4:])
+	d.Gid = e.Uint16(b[6:])
+	d.Mtime = int32(e.Uint32(b[8:]))
+	d.InodeNumber = e.Uint32(b[12:])
+	d.StartBlock = e.Uint32(b[16:])
+	d.Nlink = e.Uint32(b[20:])
+	d.FileSize = e.Uint16(b[24:])
+	d.Offset = e.Uint16(b[26:])
+	d.ParentInode = e.Uint32(b[28:])
+}
+
 // ldirType
 type ldirInodeHeader struct {
 	inodeHeader


### PR DESCRIPTION
With larger package stores, the time it takes to find exchange directories adds up. Given that this happens at early boot, I looked into some low-hanging fruit to make the implementation faster (but perhaps more work can be moved to package-creation time).

The general technique is to cut down on memory allocations in the hot paths.