### PR TITLE
musl-gcc cross platform support

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1885,7 +1885,9 @@ func (b *Ctx) Build(ctx context.Context, buildLog io.Writer) (*pb.Meta, error) {
 				cmd := b.muslGccPath()
 				gcc := exec.Command(cmd, args...)
 				log.Printf("compiling wrapper program: %v", gcc.Args)
-				gcc.Env = env
+				if b.Hermetic {
+					gcc.Env = env
+				}
 				gcc.Stderr = os.Stderr
 				if err := gcc.Run(); err != nil {
 					return nil, err

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1145,6 +1145,24 @@ int main(int argc, char *argv[]) {
 }
 `))
 
+var muslGcc = map[string]string{
+	"amd64": "musl-gcc",
+	"i686":  "musl-gcc",
+	"arm64": "aarch64-linux-musl-gcc",
+}
+
+func (b *Ctx) muslGccPath() string {
+	cmd := muslGcc[b.Arch]
+	if b.Pkg == "musl" ||
+		b.Pkg == "gcc" ||
+		b.Pkg == "gcc-i686-host" ||
+		b.Pkg == "gcc-i686" ||
+		b.Pkg == "gcc-i686-c" {
+		cmd = configureTarget[b.Arch]
+	}
+	return cmd
+}
+
 func (b *Ctx) Build(ctx context.Context, buildLog io.Writer) (*pb.Meta, error) {
 	_, ok := configureTarget[b.Arch]
 	if !ok {
@@ -1864,14 +1882,7 @@ func (b *Ctx) Build(ctx context.Context, buildLog io.Writer) (*pb.Meta, error) {
 				// if ldflags := strings.TrimSpace(getenv("LDFLAGS")); ldflags != "" {
 				// 	args = append(args, strings.Split(ldflags, " ")...)
 				// }
-				cmd := "musl-gcc"
-				if b.Pkg == "musl" ||
-					b.Pkg == "gcc" ||
-					b.Pkg == "gcc-i686-host" ||
-					b.Pkg == "gcc-i686" ||
-					b.Pkg == "gcc-i686-c" {
-					cmd = "gcc"
-				}
+				cmd := b.muslGccPath()
 				gcc := exec.Command(cmd, args...)
 				log.Printf("compiling wrapper program: %v", gcc.Args)
 				gcc.Env = env


### PR DESCRIPTION
Instead of just invoking musl-gcc/gcc directly, it picks a platform-specific musl-gcc command and if it's meant to call gcc instead, it uses the platform-specific one.