### PR TITLE
CI improvements: branch building and go install check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   format:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         ./travis/check-txtpbfmt.sh
+
+  commands:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
     
     - name: build commands
       run: go install ./cmd/...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,3 +16,6 @@ jobs:
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         ./travis/check-txtpbfmt.sh
+    
+    - name: build commands
+      run: go install ./cmd/...


### PR DESCRIPTION
This PR adds a couple of improvements to the CI

* Makes it run on branches and PRs as well as master so pre-merged work can be checked
* Runs the `go install` command to double check compilation of the core commands still works

Demo of the new setup running is at https://github.com/palfrey/distri/actions