### PR TITLE
Architecture detection with runtime.GOARCH

### DIFF
--- a/cmd/distri/build.go
+++ b/cmd/distri/build.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sys"
 	"syscall"
 	"time"
 
@@ -148,7 +149,7 @@ func buildpkg(ctx context.Context, hermetic bool, debug string, fuse bool, pwd, 
 	}
 
 	if cross == "" {
-		cross = "amd64" // TODO: configurable / auto-detect
+		cross = sys.GOARCH
 	}
 
 	b := &build.Ctx{

--- a/cmd/distri/build.go
+++ b/cmd/distri/build.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sys"
 	"syscall"
 	"time"
 
@@ -149,7 +148,7 @@ func buildpkg(ctx context.Context, hermetic bool, debug string, fuse bool, pwd, 
 	}
 
 	if cross == "" {
-		cross = sys.GOARCH
+		cross = runtime.GOARCH
 	}
 
 	b := &build.Ctx{

--- a/cmd/distri/build.go
+++ b/cmd/distri/build.go
@@ -148,7 +148,7 @@ func buildpkg(ctx context.Context, hermetic bool, debug string, fuse bool, pwd, 
 	}
 
 	if cross == "" {
-		cross = runtime.GOARCH
+		cross = runtime.GOARCH // TODO: configurable
 	}
 
 	b := &build.Ctx{

--- a/cmd/distri/build.go
+++ b/cmd/distri/build.go
@@ -148,7 +148,7 @@ func buildpkg(ctx context.Context, hermetic bool, debug string, fuse bool, pwd, 
 	}
 
 	if cross == "" {
-		cross = runtime.GOARCH // TODO: configurable
+		cross = runtime.GOARCH
 	}
 
 	b := &build.Ctx{

--- a/cmd/distri/bump.go
+++ b/cmd/distri/bump.go
@@ -154,7 +154,7 @@ func (b *bumpctx) addPkg(pkg string) error {
 	{
 		deps := buildProto.GetDep()
 		bld := &build.Ctx{
-			Arch: runtime.GOARCH, // TODO: cross
+			Arch: runtime.GOARCH, // TODO: configurable
 			Repo: env.DefaultRepo,
 		}
 		deps = append(deps, bld.Builderdeps(&buildProto)...)

--- a/cmd/distri/bump.go
+++ b/cmd/distri/bump.go
@@ -154,7 +154,7 @@ func (b *bumpctx) addPkg(pkg string) error {
 	{
 		deps := buildProto.GetDep()
 		bld := &build.Ctx{
-			Arch: runtime.GOARCH,
+			Arch: runtime.GOARCH, // TODO: cross
 			Repo: env.DefaultRepo,
 		}
 		deps = append(deps, bld.Builderdeps(&buildProto)...)
@@ -187,7 +187,7 @@ func newBumpctx() (*bumpctx, error) {
 	b := &bumpctx{
 		// TODO: use simple.NewDirectedMatrix instead?
 		graph:      simple.NewDirectedGraph(),
-		arch:       runtime.GOARCH,
+		arch:       runtime.GOARCH, // TODO: configurable
 		byFullname: make(map[string]*bumpnode),
 		byPkg:      make(map[string]*bumpnode),
 		srcCache:   make(map[string]string),

--- a/cmd/distri/bump.go
+++ b/cmd/distri/bump.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sys"
 
 	"github.com/distr1/distri"
 	"github.com/distr1/distri/internal/build"
@@ -153,7 +154,7 @@ func (b *bumpctx) addPkg(pkg string) error {
 	{
 		deps := buildProto.GetDep()
 		bld := &build.Ctx{
-			Arch: "amd64", // TODO
+			Arch: sys.GOARCH,
 			Repo: env.DefaultRepo,
 		}
 		deps = append(deps, bld.Builderdeps(&buildProto)...)
@@ -186,7 +187,7 @@ func newBumpctx() (*bumpctx, error) {
 	b := &bumpctx{
 		// TODO: use simple.NewDirectedMatrix instead?
 		graph:      simple.NewDirectedGraph(),
-		arch:       "amd64", // TODO: configurable / auto-detect
+		arch:       sys.GOARCH,
 		byFullname: make(map[string]*bumpnode),
 		byPkg:      make(map[string]*bumpnode),
 		srcCache:   make(map[string]string),

--- a/cmd/distri/bump.go
+++ b/cmd/distri/bump.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
-	"sys"
 
 	"github.com/distr1/distri"
 	"github.com/distr1/distri/internal/build"
@@ -154,7 +154,7 @@ func (b *bumpctx) addPkg(pkg string) error {
 	{
 		deps := buildProto.GetDep()
 		bld := &build.Ctx{
-			Arch: sys.GOARCH,
+			Arch: runtime.GOARCH,
 			Repo: env.DefaultRepo,
 		}
 		deps = append(deps, bld.Builderdeps(&buildProto)...)
@@ -187,7 +187,7 @@ func newBumpctx() (*bumpctx, error) {
 	b := &bumpctx{
 		// TODO: use simple.NewDirectedMatrix instead?
 		graph:      simple.NewDirectedGraph(),
-		arch:       sys.GOARCH,
+		arch:       runtime.GOARCH,
 		byFullname: make(map[string]*bumpnode),
 		byPkg:      make(map[string]*bumpnode),
 		srcCache:   make(map[string]string),

--- a/cmd/distri/log.go
+++ b/cmd/distri/log.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
-	"sys"
 	"syscall"
 
 	"github.com/distr1/distri"
@@ -37,7 +37,7 @@ func showlog(ctx context.Context, args []string) error {
 	pkg := fset.Arg(0)
 
 	if *cross == "" {
-		*cross = sys.GOARCH
+		*cross = runtime.GOARCH
 	}
 
 	var match string

--- a/cmd/distri/log.go
+++ b/cmd/distri/log.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sys"
 	"syscall"
 
 	"github.com/distr1/distri"
@@ -36,7 +37,7 @@ func showlog(ctx context.Context, args []string) error {
 	pkg := fset.Arg(0)
 
 	if *cross == "" {
-		*cross = "amd64" // TODO: native
+		*cross = sys.GOARCH
 	}
 
 	var match string

--- a/cmd/distri/pack.go
+++ b/cmd/distri/pack.go
@@ -278,7 +278,7 @@ func pack(ctx context.Context, args []string) error {
 
 		// Remove packages we don’t need to reduce docker container size:
 		b := &build.Ctx{
-			Arch: runtime.GOARCH,
+			Arch: runtime.GOARCH, // TODO: configurable
 			Repo: env.DefaultRepo,
 		} // TODO: introduce a packctx, make glob take a common ctx
 		resolved, err := b.Glob(p.repo, []string{
@@ -404,7 +404,7 @@ HOME_URL=https://distr1.org
 	}
 
 	b := &build.Ctx{
-		Arch: runtime.GOARCH,
+		Arch: runtime.GOARCH, // TODO: configurable
 		Repo: env.DefaultRepo,
 	} // TODO: introduce a packctx, make glob take a common ctx
 

--- a/cmd/distri/pack.go
+++ b/cmd/distri/pack.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
-	"sys"
 	"syscall"
 	"unsafe"
 
@@ -278,7 +278,7 @@ func pack(ctx context.Context, args []string) error {
 
 		// Remove packages we don’t need to reduce docker container size:
 		b := &build.Ctx{
-			Arch: sys.GOARCH,
+			Arch: runtime.GOARCH,
 			Repo: env.DefaultRepo,
 		} // TODO: introduce a packctx, make glob take a common ctx
 		resolved, err := b.Glob(p.repo, []string{
@@ -404,7 +404,7 @@ HOME_URL=https://distr1.org
 	}
 
 	b := &build.Ctx{
-		Arch: sys.GOARCH,
+		Arch: runtime.GOARCH,
 		Repo: env.DefaultRepo,
 	} // TODO: introduce a packctx, make glob take a common ctx
 

--- a/cmd/distri/pack.go
+++ b/cmd/distri/pack.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sys"
 	"syscall"
 	"unsafe"
 
@@ -277,7 +278,7 @@ func pack(ctx context.Context, args []string) error {
 
 		// Remove packages we don’t need to reduce docker container size:
 		b := &build.Ctx{
-			Arch: "amd64",
+			Arch: sys.GOARCH,
 			Repo: env.DefaultRepo,
 		} // TODO: introduce a packctx, make glob take a common ctx
 		resolved, err := b.Glob(p.repo, []string{
@@ -403,7 +404,7 @@ HOME_URL=https://distr1.org
 	}
 
 	b := &build.Ctx{
-		Arch: "amd64",
+		Arch: sys.GOARCH,
 		Repo: env.DefaultRepo,
 	} // TODO: introduce a packctx, make glob take a common ctx
 

--- a/cmd/distri/patch.go
+++ b/cmd/distri/patch.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sys"
 	"syscall"
 
 	"github.com/distr1/distri/internal/build"
@@ -133,7 +134,7 @@ func patch(ctx context.Context, args []string) error {
 	p := &patchctx{
 		build.Ctx{
 			Pkg:     *pkg,
-			Arch:    "amd64", // TODO: -cross flag
+			Arch:    sys.GOARCH, // TODO: -cross flag
 			Version: buildProto.GetVersion(),
 			Proto:   &buildProto,
 		},

--- a/cmd/distri/patch.go
+++ b/cmd/distri/patch.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
-	"sys"
 	"syscall"
 
 	"github.com/distr1/distri/internal/build"
@@ -134,7 +134,7 @@ func patch(ctx context.Context, args []string) error {
 	p := &patchctx{
 		build.Ctx{
 			Pkg:     *pkg,
-			Arch:    sys.GOARCH, // TODO: -cross flag
+			Arch:    runtime.GOARCH, // TODO: -cross flag
 			Version: buildProto.GetVersion(),
 			Proto:   &buildProto,
 		},

--- a/cmd/distri/run.go
+++ b/cmd/distri/run.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
-	"sys"
 	"syscall"
 
 	"github.com/distr1/distri/internal/build"
@@ -47,7 +47,7 @@ func run(ctx context.Context, args []string) error {
 	cmd := fset.Args()
 
 	p := &build.Ctx{
-		Arch: sys.GOARCH, // TODO: -cross flag
+		Arch: runtime.GOARCH, // TODO: -cross flag
 		Repo: env.DefaultRepo,
 	}
 

--- a/cmd/distri/run.go
+++ b/cmd/distri/run.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sys"
 	"syscall"
 
 	"github.com/distr1/distri/internal/build"
@@ -46,7 +47,7 @@ func run(ctx context.Context, args []string) error {
 	cmd := fset.Args()
 
 	p := &build.Ctx{
-		Arch: "amd64", // TODO: -cross flag
+		Arch: sys.GOARCH, // TODO: -cross flag
 		Repo: env.DefaultRepo,
 	}
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -355,7 +355,7 @@ type Ctx struct {
 
 func NewCtx() (*Ctx, error) {
 	return &Ctx{
-		Arch: runtime.GOARCH,
+		Arch: runtime.GOARCH, // TODO: configurable
 		Repo: env.DefaultRepo,
 	}, nil
 }
@@ -970,7 +970,7 @@ func (b *Ctx) runtimeEnv(deps []string) []string {
 func (b *Ctx) Builderdeps(p *pb.Build) []string {
 	var deps []string
 	if builder := p.Builder; builder != nil {
-		const native = runtime.GOARCH
+		const native = runtime.GOARCH // TODO: configurable
 		// The C builder dependencies are re-used by many other builders
 		// (anything that supports linking against C libraries).
 		nativeDeps := []string{

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -19,11 +19,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"sys"
 	"syscall"
 	"text/template"
 	"time"
@@ -355,7 +355,7 @@ type Ctx struct {
 
 func NewCtx() (*Ctx, error) {
 	return &Ctx{
-		Arch: sys.GOARCH,
+		Arch: runtime.GOARCH,
 		Repo: env.DefaultRepo,
 	}, nil
 }
@@ -970,7 +970,7 @@ func (b *Ctx) runtimeEnv(deps []string) []string {
 func (b *Ctx) Builderdeps(p *pb.Build) []string {
 	var deps []string
 	if builder := p.Builder; builder != nil {
-		const native = sys.GOARCH
+		const native = runtime.GOARCH
 		// The C builder dependencies are re-used by many other builders
 		// (anything that supports linking against C libraries).
 		nativeDeps := []string{
@@ -1007,7 +1007,7 @@ func (b *Ctx) Builderdeps(p *pb.Build) []string {
 			}...)
 		}
 
-		if b.Arch == sys.GOARCH {
+		if b.Arch == runtime.GOARCH {
 			nativeDeps = append(nativeDeps, "gcc", "binutils")
 		} else {
 			nativeDeps = append(nativeDeps,
@@ -1446,7 +1446,7 @@ func (b *Ctx) Build(ctx context.Context, buildLog io.Writer) (*pb.Meta, error) {
 				return nil, err
 			}
 
-			if b.Arch != sys.GOARCH {
+			if b.Arch != runtime.GOARCH {
 				// gcc-i686 and binutils-i686 are built with --sysroot=/,
 				// meaning they will search for startup files (e.g. crt1.o) in
 				// $(sysroot)/lib.

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sys"
 	"syscall"
 	"text/template"
 	"time"
@@ -354,7 +355,7 @@ type Ctx struct {
 
 func NewCtx() (*Ctx, error) {
 	return &Ctx{
-		Arch: "amd64", // TODO
+		Arch: sys.GOARCH,
 		Repo: env.DefaultRepo,
 	}, nil
 }
@@ -969,7 +970,7 @@ func (b *Ctx) runtimeEnv(deps []string) []string {
 func (b *Ctx) Builderdeps(p *pb.Build) []string {
 	var deps []string
 	if builder := p.Builder; builder != nil {
-		const native = "amd64" // TODO: configurable / auto-detect
+		const native = sys.GOARCH
 		// The C builder dependencies are re-used by many other builders
 		// (anything that supports linking against C libraries).
 		nativeDeps := []string{
@@ -1006,8 +1007,7 @@ func (b *Ctx) Builderdeps(p *pb.Build) []string {
 			}...)
 		}
 
-		// TODO: check for native
-		if b.Arch == "amd64" {
+		if b.Arch == sys.GOARCH {
 			nativeDeps = append(nativeDeps, "gcc", "binutils")
 		} else {
 			nativeDeps = append(nativeDeps,
@@ -1446,8 +1446,7 @@ func (b *Ctx) Build(ctx context.Context, buildLog io.Writer) (*pb.Meta, error) {
 				return nil, err
 			}
 
-			// TODO: test for cross
-			if b.Arch != "amd64" {
+			if b.Arch != sys.GOARCH {
 				// gcc-i686 and binutils-i686 are built with --sysroot=/,
 				// meaning they will search for startup files (e.g. crt1.o) in
 				// $(sysroot)/lib.

--- a/internal/build/buildcmake.go
+++ b/internal/build/buildcmake.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"strconv"
+	"sys"
 
 	"github.com/distr1/distri/pb"
 )
@@ -16,7 +17,7 @@ func (b *Ctx) buildcmake(opts *pb.CMakeBuilder, env []string) (newSteps []*pb.Bu
 		"-G", "Ninja",
 	}, opts.GetExtraCmakeFlag()...)
 	// TODO: apply this unconditionally (rebuild all packages)
-	if b.Arch != "amd64" {
+	if b.Arch != sys.GOARCH {
 		// From https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/CrossCompiling:
 		// If this compiler is a gcc-cross compiler with a prefixed name
 		// (e.g. "arm-elf-gcc") CMake will detect this and automatically find

--- a/internal/build/buildcmake.go
+++ b/internal/build/buildcmake.go
@@ -1,8 +1,8 @@
 package build
 
 import (
+	"runtime"
 	"strconv"
-	"sys"
 
 	"github.com/distr1/distri/pb"
 )
@@ -17,7 +17,7 @@ func (b *Ctx) buildcmake(opts *pb.CMakeBuilder, env []string) (newSteps []*pb.Bu
 		"-G", "Ninja",
 	}, opts.GetExtraCmakeFlag()...)
 	// TODO: apply this unconditionally (rebuild all packages)
-	if b.Arch != sys.GOARCH {
+	if b.Arch != runtime.GOARCH {
 		// From https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/CrossCompiling:
 		// If this compiler is a gcc-cross compiler with a prefixed name
 		// (e.g. "arm-elf-gcc") CMake will detect this and automatically find

--- a/internal/fuse/fuse.go
+++ b/internal/fuse/fuse.go
@@ -705,7 +705,7 @@ func (fs *fuseFS) scanPackages(mu sync.Locker, pkgs []string) error {
 		}
 		for deleted := range existing {
 			var standin string
-			for _, arch := range []string{"amd64", "i686"} {
+			for arch := range distri.Architectures {
 				archmiddle := "-" + arch + "-"
 				if !strings.Contains(deleted, archmiddle) {
 					continue


### PR DESCRIPTION
This PR replaces most of the instances of hardcoded "amd64" with runtime.GOARCH, so at least native builds work better on non-amd64 systems.